### PR TITLE
Shorten pantry list headers for mobile

### DIFF
--- a/src/app/components/pantry-list/pantry-list.component.ts
+++ b/src/app/components/pantry-list/pantry-list.component.ts
@@ -31,17 +31,26 @@ import { CommonModule } from '@angular/common';
         } @else {
           <table mat-table [dataSource]="pantryItemsSig()" class="mat-elevation-z1 full-width">
             <ng-container matColumnDef="name">
-              <th mat-header-cell *matHeaderCellDef>Megnevezés</th>
+              <th mat-header-cell *matHeaderCellDef>
+                <span class="label-desktop">Megnevezés</span>
+                <abbr class="label-mobile" title="Megnevezés">Név</abbr>
+              </th>
               <td mat-cell *matCellDef="let item">{{ item.name }}</td>
             </ng-container>
 
             <ng-container matColumnDef="quantity">
-              <th mat-header-cell *matHeaderCellDef>Mennyiség</th>
+              <th mat-header-cell *matHeaderCellDef>
+                <span class="label-desktop">Mennyiség</span>
+                <abbr class="label-mobile" title="Mennyiség">Menny.</abbr>
+              </th>
               <td mat-cell *matCellDef="let item">{{ item.quantity }}</td>
             </ng-container>
 
             <ng-container matColumnDef="unit">
-              <th mat-header-cell *matHeaderCellDef>Mértékegység</th>
+              <th mat-header-cell *matHeaderCellDef>
+                <span class="label-desktop">Mértékegység</span>
+                <abbr class="label-mobile" title="Mértékegység">ME</abbr>
+              </th>
               <td mat-cell *matCellDef="let item">{{ item.unit }}</td>
             </ng-container>
 
@@ -79,6 +88,14 @@ import { CommonModule } from '@angular/common';
       color: var(--mat-sys-on-surface-variant);
       font-style: italic;
       padding: 8px 0;
+    }
+
+    /* Responsive header labels */
+    .label-mobile { display: none; }
+    .label-desktop { display: inline; }
+    @media (max-width: 600px) {
+      .label-desktop { display: none; }
+      .label-mobile { display: inline; }
     }
   `]
 })


### PR DESCRIPTION
Add responsive abbreviated headers to the pantry list table to prevent overflow on mobile devices.

---
<a href="https://cursor.com/background-agent?bcId=bc-2c67c61c-f578-43fe-8664-4d6f1b3bf724">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2c67c61c-f578-43fe-8664-4d6f1b3bf724">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

